### PR TITLE
User can add to order feature

### DIFF
--- a/cypress/fixtures/order_post_response.json
+++ b/cypress/fixtures/order_post_response.json
@@ -1,5 +1,5 @@
 {
-  "message": "The product has been added to your order",
+  "message": "A product has been added to your order",
   "order":{
     "id": 1,
     "total" : 70,

--- a/cypress/fixtures/order_post_response.json
+++ b/cypress/fixtures/order_post_response.json
@@ -1,0 +1,14 @@
+{
+  "message": "The product has been added to your order",
+  "order":{
+    "id": 1,
+    "total" : 70,
+    "products": [
+      {
+        "amount": 1,
+        "name": "Pizza",
+        "price": 70
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/order_put_response.json
+++ b/cypress/fixtures/order_put_response.json
@@ -1,0 +1,19 @@
+  {
+    "message": "Another product has been added to your order",
+    "order": {
+      "id": 1,
+      "total": 170,
+      "products": [
+        {
+          "amount": 1,
+          "name": "Falafel", 
+          "price": 100
+        },
+        {
+          "amount":1,
+          "name": "Pizza",
+          "price": 70
+        }
+      ]
+    }
+  }

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -28,15 +28,24 @@ describe('User can add a product to his/her order', () => {
       method: "POST",
       url: "http://localhost:3000/api/v1/orders",
       response: "fixture:order_post_response",
+      response: {
+        message: "A product has been added to your order",
+        order: {
+          id: 1,
+        }
+      },
+
+
     });
 
     cy.route({
       method: "PUT",
       url: "http://localhost:3000/api/orders/1",
       response: {
-        message: "The product has been added to your order",
-        order_id: 1,
-      },
+        message: "Another product has been added to your order",
+        order: {
+          id:1,
+        }
     });
   });
 
@@ -44,16 +53,16 @@ describe('User can add a product to his/her order', () => {
     cy.get("#product-1").within(() => {
       cy.get("button").contains("Add to order").click();
       cy.get("#order-message").should("contain",
-        "The product has been added to your order"
-      );
+        "A product has been added to your order"
     });
-    cy.get("product-3").within(() => {
+    
+    cy.get("#product-3").within(() => {
       cy.get("button").contains("Add to order").click();
-      cy.get('.message').should(
+      cy.get("#order-message").should(
         "contain",
-        "The product has been added to your order"
+        "Another product has been added to your order"
       );
-    });
+
 
   });
 

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -34,7 +34,7 @@ describe('User can add a product to his/her order', () => {
       method: "PUT",
       url: "http://localhost:3000/api/orders/1",
       response: {
-        message: "The product has been added to order",
+        message: "The product has been added to your order",
         order_id: 1,
       },
     });

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -32,7 +32,7 @@ describe('User can add a product to his/her order', () => {
 
     cy.route({
       method: "PUT",
-      url: "http://localhost:3000/api/v1/orders",
+      url: "http://localhost:3000/api/v1/orders/1",
       response: "fixture:order_put_response",
     });
   });
@@ -44,7 +44,6 @@ describe('User can add a product to his/her order', () => {
         "A product has been added to your order"
       );
     });
-
     
 
     cy.get("#product-2").within(() => {

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -1,12 +1,12 @@
-describe("User can add a product to their order", () => {
-  before(() => {
-    cy.server()
+describe('User can add a product to his/her order', () => {
+  beforeEach(() => {
+    cy.server();
     cy.route({
-      method: "GET",
-      url: "http://localhost:3000/api/v1/products",
-      response: "fixture:products.json"
-    })
-
+      method: 'GET',
+      url: 'http://localhost:3000/api/v1/products',
+      response: "fixture:products.json",
+    });
+    
     cy.visit("/")
     cy.route({
       method: "POST",
@@ -23,11 +23,38 @@ describe("User can add a product to their order", () => {
       cy.get("#password").type("password")
       cy.get('button').contains("Submit").click()
     })
-  })
 
-  it("user can see add to order button when logged in", () => {
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/v1/orders",
+      response: "fixture:order_post_response",
+    });
+
+    cy.route({
+      method: "PUT",
+      url: "http://localhost:3000/api/orders/1",
+      response: {
+        message: "The product has been added to order",
+        order_id: 1,
+      },
+    });
+  });
+
+  it("user get a confirmation when adding product to order", () => {
     cy.get("#product-1").within(() => {
-      cy.get("button").contains("Add to order").click()
-    })
-  })
-})
+      cy.get("button").contains("Add to order").click();
+      cy.get("#order-message").should("contain",
+        "The product has been added to your order"
+      );
+    });
+    cy.get("product-3").within(() => {
+      cy.get("button").contains("Add to order").click();
+      cy.get('.message').should(
+        "contain",
+        "The product has been added to your order"
+      );
+    });
+
+  });
+
+});

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -28,24 +28,12 @@ describe('User can add a product to his/her order', () => {
       method: "POST",
       url: "http://localhost:3000/api/v1/orders",
       response: "fixture:order_post_response",
-      response: {
-        message: "A product has been added to your order",
-        order: {
-          id: 1,
-        }
-      },
-
-
     });
 
     cy.route({
       method: "PUT",
-      url: "http://localhost:3000/api/orders/1",
-      response: {
-        message: "Another product has been added to your order",
-        order: {
-          id:1,
-        }
+      url: "http://localhost:3000/api/v1/orders",
+      response: "fixture:order_put_response",
     });
   });
 
@@ -54,15 +42,17 @@ describe('User can add a product to his/her order', () => {
       cy.get("button").contains("Add to order").click();
       cy.get("#order-message").should("contain",
         "A product has been added to your order"
+      );
     });
+
     
-    cy.get("#product-3").within(() => {
+
+    cy.get("#product-2").within(() => {
       cy.get("button").contains("Add to order").click();
-      cy.get("#order-message").should(
-        "contain",
+      cy.get('#order-message').should("contain",
         "Another product has been added to your order"
       );
-
+    });
 
   });
 

--- a/cypress/integration/userCanSeeAddToOrderButton.feature.js
+++ b/cypress/integration/userCanSeeAddToOrderButton.feature.js
@@ -1,0 +1,32 @@
+describe("User can see add to order button", () => {
+  before(() => {
+    cy.server()
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/products",
+      response: "fixture:products.json"
+    })
+
+    cy.visit("/")
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/v1/auth",
+      response: "fixture:registration_response.json",
+      headers: {
+        uid: "user@mail.com"
+      }
+    })
+    cy.get("#login").click()
+    cy.get("#login-form").within(() => {
+      cy.get("#email").type("user@mail.com")
+      cy.get("#password").type("password")
+      cy.get('button').contains("Submit").click()
+    })
+  })
+
+  it("user can see add to order button when logged in", () => {
+    cy.get("#product-1").within(() => {
+      cy.get("button").contains("Add to order").click()
+    })
+  })
+})

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -3,11 +3,67 @@ import axios from "axios";
 class Menu extends Component {
   state = {
     menu: [],
+    orderMessage: {},
+    orderDetails: {}
   };
   componentDidMount = async () => {
     let menuData = await axios.get("/products");
     this.setState({ menu: menuData.data.products });
   };
+
+  addToOrder = async (event) => {
+    let productId = event.target.parentElement.dataset.id
+
+    let credentials = await JSON.parse(sessionStorage.getItem("credentials"))
+    let headers = {
+      ...credentials,
+      "Content-type": "application/json",
+      Accept: "application/json"
+    }
+
+    let response
+    if (this.state.orderDetails.hasOwnProperty('id')) {
+      response = await axios.put(`/orders/${this.state.orderDetails.id}`, {
+        product_id: productId
+      }, {
+        headers: headers
+      })
+    } else {
+      response = await axios.post('/orders', {
+        product_id: productId
+      }, {
+        headers: headers
+      })
+    }
+
+    this.setState({
+      orderMessage: {
+        message: response.data.message,
+        id: productId
+      },
+      orderDetails: response.data.order
+    })
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   render() {
     let starters = [];
     let maincourses = [];
@@ -22,6 +78,10 @@ class Menu extends Component {
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
               </button>}
+
+            {parseInt(this.state.orderMessage.id) === product.id && 
+              <p id="order-message">{this.state.orderMessage.message}</p>
+            }
             </div>
           );
         if (product.category === "main_courses")

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 import axios from "axios";
+
+
 class Menu extends Component {
   state = {
     menu: [],
@@ -8,12 +10,12 @@ class Menu extends Component {
     orderId: null
   };
   componentDidMount = async () => {
+    
     let menuData = await axios.get("/products");
     this.setState({ menu: menuData.data.products });
   };
 
   addToOrder = async (event) => {
-  
     let productId = event.target.parentElement.dataset.id
     let credentials = await JSON.parse(sessionStorage.getItem("credentials"))
     let headers = {
@@ -124,6 +126,10 @@ class Menu extends Component {
             </div>
           );
       });
+    
+    
+   
+    
     return (
       <div>
         <div id="starters">

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -4,7 +4,8 @@ class Menu extends Component {
   state = {
     menu: [],
     orderMessage: {},
-    orderDetails: {}
+    orderDetails: {},
+    orderId: null
   };
   componentDidMount = async () => {
     let menuData = await axios.get("/products");
@@ -12,7 +13,7 @@ class Menu extends Component {
   };
 
   addToOrder = async (event) => {
-
+  
     let productId = event.target.parentElement.dataset.id
     let credentials = await JSON.parse(sessionStorage.getItem("credentials"))
     let headers = {
@@ -82,6 +83,9 @@ class Menu extends Component {
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
                 </button>}
+                {parseInt(this.state.orderMessage.id) === product.id && 
+              <p id="order-message">{this.state.orderMessage.message}</p>
+            }
             </div>
           );
         if (product.category === "desserts")
@@ -96,6 +100,9 @@ class Menu extends Component {
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
               </button>}
+              {parseInt(this.state.orderMessage.id) === product.id && 
+              <p id="order-message">{this.state.orderMessage.message}</p>
+            }
             </div>
           );
 
@@ -111,6 +118,9 @@ class Menu extends Component {
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
               </button>}
+              {parseInt(this.state.orderMessage.id) === product.id && 
+              <p id="order-message">{this.state.orderMessage.message}</p>
+            }
             </div>
           );
       });

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -12,8 +12,8 @@ class Menu extends Component {
   };
 
   addToOrder = async (event) => {
-    let productId = event.target.parentElement.dataset.id
 
+    let productId = event.target.parentElement.dataset.id
     let credentials = await JSON.parse(sessionStorage.getItem("credentials"))
     let headers = {
       ...credentials,
@@ -45,25 +45,6 @@ class Menu extends Component {
     })
   }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   render() {
     let starters = [];
     let maincourses = [];
@@ -73,7 +54,12 @@ class Menu extends Component {
       this.state.menu.forEach((product) => {
         if (product.category === "starters")
           starters.push(
-            <div key={product.id} id={`product-${product.id}`}>
+            <div 
+            key={product.id} 
+            id={`product-${product.id}`}
+            data-id={product.id}
+            data-price={product.price}
+            >
               {`${product.name} ${product.description} ${product.price}`}
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
@@ -86,7 +72,12 @@ class Menu extends Component {
           );
         if (product.category === "main_courses")
           maincourses.push(
-            <div key={product.id} id={`product-${product.id}`}>
+            <div 
+            key={product.id} 
+            id={`product-${product.id}`}
+            data-id={product.id}
+            data-price={product.price}
+            >
               {`${product.name} ${product.description} ${product.price}`}
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
@@ -95,7 +86,12 @@ class Menu extends Component {
           );
         if (product.category === "desserts")
           desserts.push(
-            <div key={product.id} id={`product-${product.id}`}>
+            <div 
+            key={product.id} 
+            id={`product-${product.id}`}
+            data-id={product.id}
+            data-price={product.price}
+            >
               {`${product.name} ${product.description} ${product.price}`}
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order
@@ -105,7 +101,12 @@ class Menu extends Component {
 
         if (product.category === "drinks")
           drinks.push(
-            <div key={product.id} id={`product-${product.id}`}>
+            <div 
+            key={product.id} 
+            id={`product-${product.id}`}
+            data-id={product.id}
+            data-price={product.price}
+            >
               {`${product.name} ${product.description} ${product.price}`}
               {this.props.authenticated && <button id="button" onClick={this.addToOrder}>
                 Add to order


### PR DESCRIPTION
## [PT board URL]( link )
### User Story
```
As a visitor,
In order to select products I want to buy
I would like to be able to add products to an order

Each item needs an add button
Add button needs to lead to action where item is placed in an order basket
Order basket should be able to store restaurant items including price
Should not need to be logged in
```
## Changes proposed in this pull request:
* Testing for user adding to order.
* Code for adding to order with price.
## What I have learned working on this feature:
* Working with fixtures.
* Working with PUT and POST requests.

## Screenshots (Client)
![Screenshot 2020-07-10 at 20 54 26](https://user-images.githubusercontent.com/65346980/87188703-96ba8580-c2ef-11ea-91d1-71665b42926e.png)
